### PR TITLE
chore: StorageUsage task NEEDs wait mo server started.

### DIFF
--- a/cmd/mo-service/main.go
+++ b/cmd/mo-service/main.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"go.uber.org/automaxprocs/maxprocs"
 	"net/http"
 	"os"
 	"os/signal"
@@ -32,6 +31,7 @@ import (
 	_ "time/tzdata"
 
 	"github.com/google/uuid"
+	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap"
 
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
@@ -44,6 +44,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/system"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/frontend"
 	"github.com/matrixorigin/matrixone/pkg/gossip"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -489,7 +490,10 @@ func initTraceMetric(ctx context.Context, st metadata.ServiceType, cfg *Config, 
 	}
 	if !SV.DisableMetric || SV.EnableMetricToProm {
 		stopper.RunNamedTask("metric", func(ctx context.Context) {
-			if act := mometric.InitMetric(ctx, nil, &SV, UUID, nodeRole, mometric.WithWriterFactory(writerFactory)); !act {
+			if act := mometric.InitMetric(ctx, nil, &SV, UUID, nodeRole,
+				mometric.WithWriterFactory(writerFactory),
+				mometric.WithFrontendServerStarted(frontend.MoServerIsStarted),
+			); !act {
 				return
 			}
 			<-ctx.Done()

--- a/pkg/util/metric/mometric/metric.go
+++ b/pkg/util/metric/mometric/metric.go
@@ -135,6 +135,7 @@ func InitMetric(ctx context.Context, ieFactory func() ie.InternalExecutor, SV *c
 	}
 
 	enable = true
+	frontendServerStarted = initOpts.frontendServerStarted
 	SetUpdateStorageUsageInterval(initOpts.updateInterval)
 	SetStorageUsageCheckNewInterval(initOpts.checkNewInterval)
 	logutil.Debugf("metric with ExportInterval: %v", initOpts.exportInterval)
@@ -374,6 +375,8 @@ type InitOptions struct {
 	checkNewInterval time.Duration
 	// internalGatherInterval, handle metric.SubSystemMO gather interval
 	internalGatherInterval time.Duration
+	// frontendServerStarted, function return bool, represent server started or not
+	frontendServerStarted func() bool
 }
 
 type InitOption func(*InitOptions)
@@ -416,6 +419,12 @@ func withCheckNewInterval(interval time.Duration) InitOption {
 func WithInternalGatherInterval(interval time.Duration) InitOption {
 	return InitOption(func(options *InitOptions) {
 		options.internalGatherInterval = interval
+	})
+}
+
+func WithFrontendServerStarted(f func() bool) InitOption {
+	return InitOption(func(options *InitOptions) {
+		options.frontendServerStarted = f
 	})
 }
 


### PR DESCRIPTION
- fix import-cycle issue

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16724

## What this PR does / why we need it:
changed:
1. check mo server started before do StroageUsage task.
2. fix import-cycled between frontend and mometric.